### PR TITLE
Fixes #4, converting to JSON needed a higher depth limit

### DIFF
--- a/CloudiQ/functions/Invoke-CloudiQApiRequest.ps1
+++ b/CloudiQ/functions/Invoke-CloudiQApiRequest.ps1
@@ -7,8 +7,7 @@ function Invoke-CloudiQApiRequest {
         [Parameter(Position = 1)]
         [string]
         $Method = "Get",
-        [Parameter(Position = 2)]
-        [string]
+        [Parameter(Position = 2, ValueFromPipeline = $true)]
         $Body,
         [Parameter(Position = 3)]
         [switch]
@@ -20,12 +19,13 @@ function Invoke-CloudiQApiRequest {
             Method      = $Method
             ContentType = 'application/json'
             Headers     = @{
+                'Accept'        = 'application/json'
                 'Authorization' = "Bearer $CloudIqAccessToken"
             }
         }
         # If statement to include $Body, due to limitations in Invoke-RestMethod on Windows PowerShell.
         if ($Body) {
-            $result = Invoke-RestMethod @restSplat -Body $Body -ErrorAction Stop
+            $result = Invoke-RestMethod @restSplat -Body ($Body | ConvertTo-Json -Depth 10) -ErrorAction Stop
         }
         else {
             $result = Invoke-RestMethod @restSplat -ErrorAction Stop
@@ -33,7 +33,6 @@ function Invoke-CloudiQApiRequest {
     }
     catch {
         Write-Error $_.Exception.Message
-        Write-Warning "There are no access token set. Please run Connect-CloudiQ and log in to generate one."
         break
     }
 

--- a/CloudiQ/functions/subscription/Get-CloudiQSubscription.ps1
+++ b/CloudiQ/functions/subscription/Get-CloudiQSubscription.ps1
@@ -77,7 +77,7 @@ function Get-CloudiQSubscription {
             Publisher      = $_.publisher.name
             Product        = $_.Name
             ProductId      = $_.Product.Id
-            SubscriptionId = $_.EntitlementId
+            SubscriptionId = $_.Id
             Quantity       = $_.Quantity
             Organization   = $_.Organization.Name
         }

--- a/CloudiQ/functions/subscription/Set-CloudiQSubscription.ps1
+++ b/CloudiQ/functions/subscription/Set-CloudiQSubscription.ps1
@@ -64,7 +64,7 @@ function Set-CloudiQSubscription {
     $callParam = @{
         Uri     = ("subscriptions/$SubscriptionId")
         Method  = 'PUT'
-        Body    = ($subscription | ConvertTo-Json)
+        Body    = ($subscription)
     }
     $APICall = Invoke-CloudiQApiRequest @callParam
 


### PR DESCRIPTION
Issue was related to _ConvertTo-Json_. The entire JSON had more than 2 levels, the default depth limit of _ConvertTo-Json_. For now, it is set to 10 levels deep but I will talk to Cloud-iQ development team to narrow this down to a realistic maximum.